### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,3 @@
+[![Board Status](https://dev.azure.com/enstoa/1b89cec7-1f3d-433c-b9a9-ab21275bd9ec/657181f0-cf1a-4a0d-9efb-35f08100ad3f/_apis/work/boardbadge/218b4f22-05bc-4858-a7a1-8df3092385a3)](https://dev.azure.com/enstoa/1b89cec7-1f3d-433c-b9a9-ab21275bd9ec/_boards/board/t/657181f0-cf1a-4a0d-9efb-35f08100ad3f/Microsoft.RequirementCategory)
 # sf-web-app
 Starfish Web Application


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#19315](https://dev.azure.com/enstoa/1b89cec7-1f3d-433c-b9a9-ab21275bd9ec/_workitems/edit/19315). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.